### PR TITLE
Live2D: fix render bug with certain models

### DIFF
--- a/js/l2d/DirectorLite.js
+++ b/js/l2d/DirectorLite.js
@@ -237,6 +237,8 @@ DirectorLite.prototype.reshape = function() {
     var width = this.canvas.width;
     var height = this.canvas.height;
 
+    this.gl.viewport(0, 0, width, height);
+
     var ratio = height / width;
     var left = -0.5;
     var right = 0.5;
@@ -285,8 +287,9 @@ DirectorLite.prototype.prepareCanvas = function(named, webglFail) {
     }
 
     this.dragMgr = new L2DTargetPoint();
-    this.reshape();
     this.gl = this.getWebGLContext();
+    this.reshape();
+
     if (!this.gl) {
         if (webglFail) {
             webglFail(100);


### PR DESCRIPTION
This affects a bunch of Michelle models, making them appear off center, distorted, or both. e.g. 
- https://bandori.party/live2d/852/Misaki-Okusawa-Pure-Smiling-Magic/ 
- https://bandori.party/live2d/726/Misaki-Okusawa-Cool-My-important-thing/
- https://bandori.party/live2d/742/Misaki-Okusawa-Power-Witch-Michelle/

I don't know why this doesn't affect other models, but the root cause was me forgetting to call glViewport after changing the canvas size, so here's a patch for that.
