### PR TITLE
Fix event gacha page to produce duplicate text

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -242,9 +242,9 @@ function loadEventGacha() {
             if (last_field.data('field') == prefix + 'image') {
                 return ;
             }
-            let original_name = field.find('th').first().text();
-            field.find('th').first().html('<h3>' + field.find('th').text() + '</h3>');
-            field.find('th').first().append('<small class="text-muted"><span class="glyphicon glyphicon-triangle-bottom"></span> <span class="text-open"></span></small>');
+            let original_name = field.find('th').last().text();
+            field.find('th').last().html('<h3>' + original_name + '</h3>');
+            field.find('th').last().append('<small class="text-muted"><span class="glyphicon glyphicon-triangle-bottom"></span> <span class="text-open"></span></small>');
             field.css('cursor', 'pointer');
             field.unbind('click');
             field.click(function(e) {


### PR DESCRIPTION
There can be multiple 'th' element found on page with the current 'field' variable.
From my observation I see that the ajax generated for modal is positioned after the main page content after open specific event on new tab.
So, I update the last 'th' element in 'field' variable because the first one will update the main page content 'th' element.

Open the gacha from event page
![Screenshot from 2019-03-13 00-02-36](https://user-images.githubusercontent.com/31300270/54220234-89d32980-4523-11e9-9e1d-6eba52fdf2f5.png)

Event page after gacha modal is closed
![Screenshot from 2019-03-13 00-03-04](https://user-images.githubusercontent.com/31300270/54220245-90fa3780-4523-11e9-91aa-3eec2d29756e.png)

I think this is applied for issue 194 and 146.